### PR TITLE
Fix missing `for` loop end

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.azurepatterns.com
+www.brentmcconnell.com

--- a/_posts/2020-03-11-jekyll-categories.md
+++ b/_posts/2020-03-11-jekyll-categories.md
@@ -60,6 +60,7 @@ layout: default
               {{ post.excerpt }}
           </span>
         </div>
+     {% endfor %}
     </div>
 </div>
 {% endraw %}


### PR DESCRIPTION
Hi @brentmcconnell,

I was using your post [Creating Jekyll Category Pages on GitHub](https://www.azurepatterns.com/2020/03/11/jekyll-categories) as a guide for adding category pages to my site, and I noticed you're missing an `{% endfor %}` in the Liquid template.

This PR should fix that.